### PR TITLE
Added spectator functionality

### DIFF
--- a/bingosync-app/bingosync/migrations/0009_player_is_specatator.py
+++ b/bingosync-app/bingosync/migrations/0009_player_is_specatator.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bingosync', '0008_game_game_type_value'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='player',
+            name='is_spectator',
+            field=models.BooleanField()
+        ),
+    ]

--- a/bingosync-app/bingosync/models.py
+++ b/bingosync-app/bingosync/models.py
@@ -230,6 +230,7 @@ class Player(models.Model):
     name = models.CharField(max_length=50)
     color_value = models.IntegerField("Color", default=Color.player_default().value, choices=Color.player_choices())
     created_date = models.DateTimeField("Creation Time", default=datetime.now)
+    is_spectator = models.BooleanField()
 
     @staticmethod
     def get_for_encoded_uuid(encoded_player_uuid):
@@ -245,6 +246,8 @@ class Player(models.Model):
 
     @property
     def color(self):
+        if self.is_spectator:
+            return Color.blank
         return Color.for_value(self.color_value)
 
     @property
@@ -261,10 +264,14 @@ class Player(models.Model):
         return color_event
 
     def to_json(self):
+        is_spectator = "false";
+        if (self.is_spectator):
+            is_spectator = "true"
         return {
             "uuid": self.encoded_uuid,
             "name": self.name,
-            "color": self.color.name
+            "color": self.color.name,
+            "is_spectator": is_spectator
         }
 
 class Event(models.Model):

--- a/bingosync-app/templates/bingosync/bingosync.html
+++ b/bingosync-app/templates/bingosync/bingosync.html
@@ -9,7 +9,7 @@
     <div class="row" style="height: calc(100% - 70px); margin-bottom: 20px;">
         <div class="col-md-6">
             <div class="fill-parent" style="text-align: center">
-                {% include 'bingosync/color_chooser.html' %}
+                {% if player.is_spectator == False %} {% include 'bingosync/color_chooser.html' %} {% endif %}
                 <div style="display: inline-block;">
                     {% include 'bingosync/board.html' %}
                 </div>
@@ -51,14 +51,15 @@
         window.sessionStorage.setItem("room", "{{ room.encoded_uuid }}");
 
         // asynchronously load and populate the board
-        initializeBoard($("#bingo"), boardUrl, goalSelectedUrl, $("#color-chooser"));
+        initializeBoard($("#bingo"), boardUrl, goalSelectedUrl, $("#color-chooser"), "{{ player.is_spectator }}" === "True");
 
         // open the chat web socket
         initializeChatSocket($("#bingo-chat"), $("#bingo"), $("#players-panel"), $("#chat-settings"),
                              socketsUrl, chatUrl, chatHistoryUrl, temporarySocketKey);
 
         // enable choosing color
-        initializeColorChooser($("#color-chooser"), "{{ player.color.goal_class }}", colorSelectedUrl);
+        if ("{{ player.is_spectator }}" === "False")
+            initializeColorChooser($("#color-chooser"), "{{ player.color.goal_class }}", colorSelectedUrl);
 
         // hook up chat contents toggling
         initializeChatSettings($("#chat-settings"), $("#bingo-chat"));

--- a/bingosync-app/templates/bingosync/players_panel.html
+++ b/bingosync-app/templates/bingosync/players_panel.html
@@ -6,6 +6,7 @@
     </div>
     <div id="players-panel" class="panel-body">
     {% for player in room.connected_players %}
+        {% if player.is_spectator == False %}
         <div id="{{ player.encoded_uuid }}">
             <span class="goalcounter {{ player.color.goal_class }}">
                 {{ game|num_goals:player.color }}
@@ -14,6 +15,7 @@
                 {{ player.name }}
             </span>
         </div>
+        {% endif %}
     {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
Hey Saltor, it's prettybigjoe.

I've had some ideas on how to improve bingosync a little based on both playing in and commentating for some matches.

This is the first idea I had -- being able to see a board without being in the players list or being able to change anything, for commentators to use.

Feel free to use whatever you want from this pull request or ignore it all, but please at least take this ideas into consideration.  I'd ask you just to do things, but I thought I might as well help out a bit.

Other ideas for the future 
- Being able to make a board without a seed and add in the seed later
- Being able to sync multiple boards so you make sure every team has the right seed (this broke one of our matches :P)
- Being able to generate the seed on-site