### PR TITLE
Feature: Non-Lockout Mode, allow multiple colors per square

### DIFF
--- a/bingosync-app/bingosync/forms.py
+++ b/bingosync-app/bingosync/forms.py
@@ -4,7 +4,7 @@ from django.contrib.auth import hashers
 
 import logging
 
-from .models import Room, GameType, Game, Player
+from .models import Room, GameType, LockoutMode, Game, Player
 
 from .goals_converter import download_and_get_converted_goal_list, DEFAULT_DOWNLOAD_URL
 
@@ -23,6 +23,7 @@ class RoomForm(forms.Form):
     passphrase = forms.CharField(label="Password", widget=forms.PasswordInput())
     nickname = forms.CharField(label="Nickname", max_length=PLAYER_NAME_MAX_LENGTH)
     game_type = forms.ChoiceField(label="Game", choices=GameType.choices())
+    lockout_mode = forms.ChoiceField(label="Lockout Mode", choices=LockoutMode.choices())
     seed = forms.CharField(label="Seed", widget=forms.NumberInput())
     is_spectator = forms.BooleanField(label="Create as Spectator", required=False)
 
@@ -31,6 +32,7 @@ class RoomForm(forms.Form):
         passphrase = self.cleaned_data["passphrase"]
         nickname = self.cleaned_data["nickname"]
         game_type = GameType.for_value(int(self.cleaned_data["game_type"]))
+        lockout_mode = LockoutMode.for_value(int(self.cleaned_data["lockout_mode"]))
         seed = self.cleaned_data["seed"]
         is_spectator = self.cleaned_data["is_spectator"]
 
@@ -40,7 +42,7 @@ class RoomForm(forms.Form):
             room.save()
 
             board_json = game_type.generator_instance().get_card(seed)
-            game = Game.from_board(board_json, room=room, game_type_value=game_type.value, seed=seed)
+            game = Game.from_board(board_json, room=room, game_type_value=game_type.value, lockout_mode_value=lockout_mode.value, seed=seed)
 
             creator = Player(room=room, name=nickname, is_spectator=is_spectator)
             creator.save()

--- a/bingosync-app/bingosync/migrations/0012_auto_20160213_1611.py
+++ b/bingosync-app/bingosync/migrations/0012_auto_20160213_1611.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bingosync', '0011_room_active'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='goalevent',
+            name='remove_color',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='square',
+            name='color_value',
+            field=models.IntegerField(default=0, choices=[(10, 'Blue Orange'), (0, 'Blank'), (19, 'Blue Purple Red'), (28, 'Green Orange Purple'), (13, 'Green Orange Red'), (7, 'Blue Green Red'), (26, 'Blue Orange Purple'), (27, 'Blue Orange Purple Red'), (20, 'Green Purple'), (11, 'Blue Orange Red'), (29, 'Green Orange Purple Red'), (17, 'Purple Red'), (22, 'Blue Green Purple'), (6, 'Blue Green'), (30, 'Blue Green Orange Purple'), (24, 'Orange Purple'), (31, 'Blue Green Orange Purple Red'), (21, 'Green Purple Red'), (16, 'Purple'), (9, 'Orange Red'), (5, 'Green Red'), (25, 'Orange Purple Red'), (14, 'Blue Green Orange'), (8, 'Orange'), (12, 'Green Orange'), (23, 'Blue Green Purple Red'), (15, 'Blue Green Orange Red'), (1, 'Red'), (3, 'Blue Red'), (18, 'Blue Purple'), (2, 'Blue'), (4, 'Green')], verbose_name='Color'),
+        ),
+    ]

--- a/bingosync-app/bingosync/migrations/0013_auto_20160213_2013.py
+++ b/bingosync-app/bingosync/migrations/0013_auto_20160213_2013.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bingosync', '0012_auto_20160213_1611'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='game',
+            name='lockout_mode_value',
+            field=models.IntegerField(verbose_name='Lockout Mode', choices=[(1, 'Non-Lockout'), (2, 'Lockout')], default=1),
+        ),
+        migrations.AlterField(
+            model_name='square',
+            name='color_value',
+            field=models.IntegerField(verbose_name='Color', choices=[(23, 'Blue Green Purple Red'), (15, 'Blue Green Orange Red'), (19, 'Blue Purple Red'), (13, 'Green Orange Red'), (9, 'Orange Red'), (14, 'Blue Green Orange'), (20, 'Green Purple'), (12, 'Green Orange'), (11, 'Blue Orange Red'), (7, 'Blue Green Red'), (5, 'Green Red'), (4, 'Green'), (6, 'Blue Green'), (21, 'Green Purple Red'), (30, 'Blue Green Orange Purple'), (28, 'Green Orange Purple'), (1, 'Red'), (25, 'Orange Purple Red'), (2, 'Blue'), (29, 'Green Orange Purple Red'), (0, 'Blank'), (31, 'Blue Green Orange Purple Red'), (10, 'Blue Orange'), (27, 'Blue Orange Purple Red'), (3, 'Blue Red'), (16, 'Purple'), (26, 'Blue Orange Purple'), (22, 'Blue Green Purple'), (18, 'Blue Purple'), (8, 'Orange'), (17, 'Purple Red'), (24, 'Orange Purple')], default=0),
+        ),
+    ]

--- a/bingosync-app/bingosync/migrations/0014_auto_20160213_2047.py
+++ b/bingosync-app/bingosync/migrations/0014_auto_20160213_2047.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bingosync', '0013_auto_20160213_2013'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='square',
+            name='color_value',
+            field=models.IntegerField(verbose_name='Color', choices=[(16, 'Purple'), (10, 'Blue Orange'), (29, 'Green Orange Purple Red'), (19, 'Blue Purple Red'), (27, 'Blue Orange Purple Red'), (31, 'Blue Green Orange Purple Red'), (12, 'Green Orange'), (14, 'Blue Green Orange'), (8, 'Orange'), (23, 'Blue Green Purple Red'), (22, 'Blue Green Purple'), (0, 'Blank'), (15, 'Blue Green Orange Red'), (9, 'Orange Red'), (30, 'Blue Green Orange Purple'), (26, 'Blue Orange Purple'), (24, 'Orange Purple'), (5, 'Green Red'), (18, 'Blue Purple'), (2, 'Blue'), (6, 'Blue Green'), (11, 'Blue Orange Red'), (21, 'Green Purple Red'), (13, 'Green Orange Red'), (4, 'Green'), (20, 'Green Purple'), (1, 'Red'), (25, 'Orange Purple Red'), (3, 'Blue Red'), (17, 'Purple Red'), (7, 'Blue Green Red'), (28, 'Green Orange Purple')], default=0),
+        ),
+    ]

--- a/bingosync-app/bingosync/migrations/0015_auto_20160213_2237.py
+++ b/bingosync-app/bingosync/migrations/0015_auto_20160213_2237.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from bingosync.models import CompositeColor, Color
+
+def update_old_square_colors(apps, schema_editor):
+    Square = apps.get_model('bingosync', Square)
+    for square in Square.objects.all():
+        composite_color = CompositeColor([Color.for_value(square.color_value)])
+        square.color_value = composite_color.value
+        square.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bingosync', '0014_auto_20160213_2047'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_old_square_colors),
+    ]

--- a/bingosync-app/bingosync/models.py
+++ b/bingosync-app/bingosync/models.py
@@ -48,7 +48,7 @@ class Color(Enum):
         return Color.red
 
     @property
-    def compositeValue(self):
+    def composite_value(self):
         if self == Color.blank:
             return 0
         exponent = self.value - 2
@@ -68,26 +68,26 @@ class CompositeColor:
         self.colors = colors
 
     def __str__(self):
-        colorNames = list(map(lambda x: x.name.capitalize(), self.colors))
-        colorNames.sort()
-        return ' '.join(colorNames)
+        color_names = list(map(lambda x: x.name.capitalize(), self.colors))
+        color_names.sort()
+        return ' '.join(color_names)
 
     @staticmethod
     def goal_choices():
-        allcolors = frozenset(Color)
-        allcolors = allcolors - set([Color.blank])
-        allsets = set(chain.from_iterable(combinations(allcolors, n) for n in range(len(allcolors)+1)))
-        allsets.remove(())
-        allsets.add(frozenset([Color.blank]))
+        all_colors = frozenset(Color)
+        all_colors = all_colors - set([Color.blank])
+        all_sets = set(chain.from_iterable(combinations(all_colors, n) for n in range(len(all_colors)+1)))
+        all_sets.remove(())
+        all_sets.add(frozenset([Color.blank]))
         choices = []
-        for possible in allsets:
+        for possible in all_sets:
             try:
                 iterator = iter(possible)
             except TypeError:
                 print(str(possible) + ' is not iterable')
             else:
-                cCol = CompositeColor(possible)
-                choices.append( (cCol.value, str(cCol)) )
+                composite_color = CompositeColor(possible)
+                choices.append( (composite_color.value, str(composite_color)) )
         return choices
 
     @staticmethod
@@ -96,13 +96,13 @@ class CompositeColor:
 
     @staticmethod
     def for_value(value):
-        colorValues = dict(map(lambda x: (x.compositeValue, x), Color))
-        del colorValues[0]
+        color_values = dict(map(lambda x: (x.composite_value, x), Color))
+        del color_values[0]
         colors = set()
-        while len(colorValues.keys()) > 0:
-            key = max(colorValues.keys())
-            color = colorValues[key]
-            del colorValues[key]
+        while len(color_values.keys()) > 0:
+            key = max(color_values.keys())
+            color = color_values[key]
+            del color_values[key]
             if value < key:
                 continue
             colors.add(color)
@@ -122,7 +122,7 @@ class CompositeColor:
         for color in self._colors:
             if color == Color.blank:
                 return 0;
-            val = val + color.compositeValue
+            val = val + color.composite_value
         return val
 
     @property
@@ -318,24 +318,23 @@ class Game(models.Model):
     def board(self):
         return [square.to_json() for square in self.squares]
 
-    def update_goal(self, player, slot, color, removeColor):
+    def update_goal(self, player, slot, color, remove_color):
         square = self.squares[slot - 1]
-        sqColor = square.color
+        square_color = square.color
 
         # Don't add the color if lockout is enabled and the square is not blank
-        if self.lockout_mode == LockoutMode.lockout and sqColor.colors != [Color.blank]:
+        if self.lockout_mode == LockoutMode.lockout and square_color.colors != [Color.blank]:
             return False
 
-        if removeColor:
-            sqColor.remove(color)
+        if remove_color:
+            square_color.remove(color)
         else:
-            if self.lockout_mode != LockoutMode.lockout or sqColor.colors == [Color.blank]:
-                sqColor.add(color)
-        square.color = sqColor
+            square_color.add(color)
+        square.color = square_color
         square.save()
 
         goal_event = GoalEvent(player=player, square=square, color_value=color.value,
-                               player_color_value=player.color.value, remove_color=removeColor)
+                               player_color_value=player.color.value, remove_color=remove_color)
         goal_event.save()
         return goal_event
 

--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse, JsonResponse, Http404
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse, Http404
 from django.shortcuts import render, redirect
 from django.core.cache import cache
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -125,6 +125,8 @@ def goal_selected(request):
     removeColor = data["removeColor"]
 
     goal_event = game.update_goal(player, slot, color, removeColor)
+    if not goal_event:
+        return HttpResponseBadRequest("Blocked by Lockout")
     publish_goal_event(goal_event)
     return HttpResponse("Recieved data: " + str(data))
 

--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -122,9 +122,9 @@ def goal_selected(request):
     game = room.current_game
     slot = int(data["slot"])
     color = Color.for_name(data["color"])
-    removeColor = data["removeColor"]
+    remove_color = data["remove_color"]
 
-    goal_event = game.update_goal(player, slot, color, removeColor)
+    goal_event = game.update_goal(player, slot, color, remove_color)
     if not goal_event:
         return HttpResponseBadRequest("Blocked by Lockout")
     publish_goal_event(goal_event)

--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -122,8 +122,9 @@ def goal_selected(request):
     game = room.current_game
     slot = int(data["slot"])
     color = Color.for_name(data["color"])
+    removeColor = data["removeColor"]
 
-    goal_event = game.update_goal(player, slot, color)
+    goal_event = game.update_goal(player, slot, color, removeColor)
     publish_goal_event(goal_event)
     return HttpResponse("Recieved data: " + str(data))
 

--- a/bingosync-app/static/bingosync/bingosync.js
+++ b/bingosync-app/static/bingosync/bingosync.js
@@ -1,6 +1,16 @@
 COLORS = ["blank", "red", "blue", "green", "purple", "orange"];
 BLANK_COLOR = "blank";
 
+var IS_LOCKOUT = null;
+
+$(function () {
+    if ($('#is-lockout').attr('value') === 'lockout') {
+        IS_LOCKOUT = true;
+    } else {
+        IS_LOCKOUT = false;
+    }
+});
+
 function getSquareColorClass(color) {
     return color + "square";
 }
@@ -11,7 +21,7 @@ function getPlayerColorClass(color) {
 
 function setSquareColor($square, newColor, removeColor) {
     var newColorClass = getSquareColorClass(newColor);
-    if ($('#allow-multi-color').prop('checked')) {
+    if (!IS_LOCKOUT) {
         if (removeColor) {
             $square.children('.' + newColorClass).remove();
         } else if (!squareHasColor($square, newColorClass)) {
@@ -106,7 +116,7 @@ function initializeBoard($board, boardUrl, goalSelectedUrl, $colorChooser, isSpe
                 removeColor = true;
             }
             // the square is a different color, but we allow multiple colors, so add it
-            else if ($('#allow-multi-color').prop('checked')) {
+            else if (!IS_LOCKOUT) {
                 removeColor = false;
             }
             // the square is colored a different color and we don't allow multiple colors, so don't do anything

--- a/bingosync-app/static/bingosync/bingosync.js
+++ b/bingosync-app/static/bingosync/bingosync.js
@@ -133,7 +133,7 @@ function initializeBoard($board, boardUrl, goalSelectedUrl, $colorChooser, isSpe
                     "slot": $(this).attr("id").substring(4),
                     "color": chosenColor,
                     // if we are removing the color, we need to know which color we are removing
-                    "removeColor": removeColor
+                    "remove_color": removeColor
                 }),
                 "error": function(result) {
                     console.log(result);

--- a/bingosync-app/static/bingosync/bingosync.js
+++ b/bingosync-app/static/bingosync/bingosync.js
@@ -9,25 +9,70 @@ function getPlayerColorClass(color) {
     return color + "player";
 }
 
-function setSquareColor($square, new_color) {
-    COLORS.forEach(function(color) {
-        $square.removeClass(getSquareColorClass(color));
-    });
-    $square.addClass(getSquareColorClass(new_color));
+function setSquareColor($square, newColor, removeColor) {
+    var newColorClass = getSquareColorClass(newColor);
+    if ($('#allow-multi-color').prop('checked')) {
+        if (removeColor) {
+            $square.children('.' + newColorClass).remove();
+        } else if (!squareHasColor($square, newColorClass)) {
+            $square.children('.blanksquare').remove();
+            $square.children('.shadow').before('<div class="bg-color ' + newColorClass + '"></div>');
+        }
+    } else {
+        $square.children('.bg-color').remove();
+        $square.children('.shadow').before('<div class="bg-color ' + newColorClass + '"></div>');
+    }
 }
 
-function setPlayerColor($playerEntry, new_color) {
+function setSquareColors($square, colors) {
+    $square.children('.bg-color').remove();
+    colors = colors.split(' ');
+    var shadow = $square.children('.shadow');
+    colors.forEach(function (color) {
+        shadow.before('<div class="bg-color ' + getSquareColorClass(color) + '"></div>');
+    });
+    updateColorOffsets($square);
+}
+
+function updateColorOffsets($square) {
+    var $colorElements = $square.children('.bg-color');
+    var numColors = $colorElements.length;
+    var translatePercent = {
+        2: ['0', '0'],
+        3: ['0', '36', '-34'],
+        4: ['0', '46', '0', '-48'],
+        5: ['0', '56', '18', '-18', '-56']
+    };
+    var translations = translatePercent[numColors];
+
+    $($colorElements[0]).css('transform', '');
+    for (var i = 1; i < $colorElements.length; ++i) {
+        var transform = 'skew(-48deg) translateX(' + translations[i] + '%)';
+        $($colorElements[i]).css('transform', transform);
+        $($colorElements[i]).css('border-right', 'solid 1.5px #444444');
+    }
+}
+
+function setPlayerColor($playerEntry, newColor) {
     var $playerGoalCounter = $playerEntry.find(".goalcounter");
     COLORS.forEach(function(color) {
         $playerGoalCounter.removeClass(getSquareColorClass(color));
     });
-    $playerGoalCounter.addClass(getSquareColorClass(new_color));
+    $playerGoalCounter.addClass(getSquareColorClass(newColor));
+}
+
+function squareHasColor($square, colorClass) {
+    return $square.children('.bg-color').any(function () {
+        if (colorClass in $(this).getClasses()) {
+            return true;
+        }
+    });
 }
 
 function initializeBoard($board, boardUrl, goalSelectedUrl, $colorChooser, isSpectator) {
     function updateSquare($square, json) {
-        $square.html(json["name"]);
-        setSquareColor($square, json["color"]);
+        $square.html('<div class="shadow"></div><div class="vertical-center">' + json["name"] + '</div>');
+        setSquareColors($square, json["colors"]);
     }
 
     function updateBoard($board, json) {
@@ -50,16 +95,21 @@ function initializeBoard($board, boardUrl, goalSelectedUrl, $colorChooser, isSpe
             var chosenColor = $colorChooser.find(".chosen-color").attr("squareColor");
             var chosenColorClass = getSquareColorClass(chosenColor);
 
-            var assignedColor;
+            // Are we adding or removing the color
+            var removeColor;
             // the square is blank and we're painting it
-            if(getSquareColorClass("blank") in $(this).getClasses()) {
-                assignedColor = chosenColor;
+            if(squareHasColor($(this), getSquareColorClass("blank"))) {
+                removeColor = false;
             }
-            // the square is colored the same as the chosen color so we're clearing it
-            else if(chosenColorClass in $(this).getClasses()) {
-                assignedColor = "blank";
+            // the square is colored the same as the chosen color so we're clearing it (or just removing the chosen color from the square's colors)
+            else if(squareHasColor($(this), chosenColorClass)) {
+                removeColor = true;
             }
-            // the square is colored a different color, so don't do anything
+            // the square is a different color, but we allow multiple colors, so add it
+            else if ($('#allow-multi-color').prop('checked')) {
+                removeColor = false;
+            }
+            // the square is colored a different color and we don't allow multiple colors, so don't do anything
             else {
                 return;
             }
@@ -71,7 +121,9 @@ function initializeBoard($board, boardUrl, goalSelectedUrl, $colorChooser, isSpe
                     "room": window.sessionStorage.getItem("room"),
                     // substring to get rid of the 'slot' in e.g. 'slot12'
                     "slot": $(this).attr("id").substring(4),
-                    "color": assignedColor
+                    "color": chosenColor,
+                    // if we are removing the color, we need to know which color we are removing
+                    "removeColor": removeColor
                 }),
                 "error": function(result) {
                     console.log(result);
@@ -198,10 +250,10 @@ function initializeChatSocket($chatWindow, $board, $playersPanel, $chatSettings,
             return $("<div>", {html: playerSpan + ": " + message}).toHtml();
         }
         else if(json["type"] === "goal") {
-            var colorClass = getPlayerColorClass(json["color"]);
+            var colorClass = json["remove"] ? getPlayerColorClass('blank') : getPlayerColorClass(json["color"]);
             var goal = $("<span>", {"class": "goal-name " + colorClass, html: json["square"]["name"]}).toHtml();
 
-            if(json["color"] === BLANK_COLOR) {
+            if(json["remove"]) {
                 return $("<div>", {"class": "goal-message", html: playerSpan + " cleared " + goal}).toHtml();
             }
             else {
@@ -242,7 +294,7 @@ function initializeChatSocket($chatWindow, $board, $playersPanel, $chatSettings,
         console.log(json);
         if(json["type"] === "goal") {
             var $square = $("#" + json["square"]["slot"]);
-            setSquareColor($square, json["square"]["color"]);
+            setSquareColors($square, json["square"]["colors"]);
             updateGoalCounters($board, $playersPanel);
         }
         else if(json["type"] === "color") {

--- a/bingosync-app/static/bingosync/misc.js
+++ b/bingosync-app/static/bingosync/misc.js
@@ -12,6 +12,21 @@ $.fn.getClasses = function() {
     return classes;
 };
 
+// Check if the provided function returns true for any member of a jQuery collection
+$.fn.any = function(func) {
+    if (typeof func !== 'function') {
+        return false;
+    }
+    var any = false;
+    $(this).each(function () {
+        if (func.call(this)) {
+            any = true;
+            return false;
+        }
+    });
+    return any;
+};
+
 $.fn.toHtml = function() {
     return $(this).wrapAll('<div>').parent().html();
 };

--- a/bingosync-app/static/bingosync/style.css
+++ b/bingosync-app/static/bingosync/style.css
@@ -2,6 +2,14 @@
     position: relative;
     top: 50%;
     transform: translateY(-50%);
+    -webkit-transform: translateY(-50%);
+    -moz-transform: translateY(-50%);
+}
+
+.vertical-center.skew {
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%) skewX(45deg);
 }
 
 .fill-parent {
@@ -123,7 +131,7 @@
 /* plain old square */
 .square {
     color: #fff;
-    text-shadow: 1px 1px 1px rgba(0,0,0,0.3);
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.5);
     padding: 0 5px;
     cursor: pointer;
     width: 105px;
@@ -131,10 +139,28 @@
     text-align: center;
     border: 1px #424242 solid;
     background: #181818;
+    vertical-align: middle;
+
+    /* position needs to be relative for overflow hidden to work */
+    position: relative;
+    overflow: hidden;
 }
 
-.square:hover,
-.square.hover {
+.square .bg-color, .square .shadow {
+    width: inherit;
+    height: inherit;
+    position: absolute;
+    left: -2px;
+}
+
+.square .bg-color {
+    transform-origin: top;
+    -webkit-transform-origin: top;
+    -moz-transform-origin: top;
+}
+
+.square:hover .shadow,
+.square.hover .shadow {
     box-shadow: inset 0px 0px 50px rgba(0, 0, 0, 0.6);
     -moz-box-shadow: inset 0px 0px 50px rgba(0, 0, 0, 0.6);
     -webkit-box-shadow: inset 0px 0px 50px rgba(0, 0, 0, 0.6);

--- a/bingosync-app/static/bingosync/style.css
+++ b/bingosync-app/static/bingosync/style.css
@@ -92,10 +92,6 @@
     overflow-y: scroll;
 }
 
-.panel-body {
-    padding:8px;
-}
-
 .chat-window {
     display: flex;
     flex-flow: column;
@@ -125,6 +121,10 @@
 
 #settings-table tr td {
     padding-right: 5px;
+}
+
+#room-settings .panel-body, #chat-settings .panel-body {
+    font-size: 90%;
 }
 
 .collapse-button {

--- a/bingosync-app/static/bingosync/style.css
+++ b/bingosync-app/static/bingosync/style.css
@@ -92,6 +92,10 @@
     overflow-y: scroll;
 }
 
+.panel-body {
+    padding:8px;
+}
+
 .chat-window {
     display: flex;
     flex-flow: column;
@@ -327,4 +331,8 @@
     color: #888;
     margin-left: 10px;
     margin-right: 10px;
+}
+
+.hidden {
+    display: none;
 }

--- a/bingosync-app/templates/bingosync/board.html
+++ b/bingosync-app/templates/bingosync/board.html
@@ -9,43 +9,43 @@
     </tr>
     <tr>
         <td class="unselectable popout" id="row1">ROW1</td>
-        <td class="unselectable square blanksquare row1 col1 tlbr" id="slot1"></td>
-        <td class="unselectable square blanksquare row1 col2" id="slot2"></td>
-        <td class="unselectable square blanksquare row1 col3" id="slot3"></td>
-        <td class="unselectable square blanksquare row1 col4" id="slot4"></td>
-        <td class="unselectable square blanksquare row1 col5 bltr" id="slot5"></td>
+        <td><div class="unselectable square blanksquare row1 col1 tlbr" id="slot1"></div></td>
+        <td><div class="unselectable square blanksquare row1 col2" id="slot2"></div></td>
+        <td><div class="unselectable square blanksquare row1 col3" id="slot3"></div></td>
+        <td><div class="unselectable square blanksquare row1 col4" id="slot4"></div></td>
+        <td><div class="unselectable square blanksquare row1 col5 bltr" id="slot5"></div></td>
     </tr>
     <tr>
         <td class="unselectable popout" id="row2">ROW2</td>
-        <td class="unselectable square blanksquare row2 col1" id="slot6"></td>
-        <td class="unselectable square blanksquare row2 col2 tlbr" id="slot7"></td>
-        <td class="unselectable square blanksquare row2 col3" id="slot8"></td>
-        <td class="unselectable square blanksquare row2 col4 bltr" id="slot9"></td>
-        <td class="unselectable square blanksquare row2 col5" id="slot10"></td>
+        <td><div class="unselectable square blanksquare row2 col1" id="slot6"></div></td>
+        <td><div class="unselectable square blanksquare row2 col2 tlbr" id="slot7"></div></td>
+        <td><div class="unselectable square blanksquare row2 col3" id="slot8"></div></td>
+        <td><div class="unselectable square blanksquare row2 col4 bltr" id="slot9"></div></td>
+        <td><div class="unselectable square blanksquare row2 col5" id="slot10"></div></td>
     </tr>
     <tr>
         <td class="unselectable popout" id="row3">ROW3</td>
-        <td class="unselectable square blanksquare row3 col1" id="slot11"></td>
-        <td class="unselectable square blanksquare row3 col2" id="slot12"></td>
-        <td class="unselectable square blanksquare row3 col3 tlbr bltr" id="slot13"></td>
-        <td class="unselectable square blanksquare row3 col4" id="slot14"></td>
-        <td class="unselectable square blanksquare row3 col5" id="slot15"></td>
+        <td><div class="unselectable square blanksquare row3 col1" id="slot11"></div></td>
+        <td><div class="unselectable square blanksquare row3 col2" id="slot12"></div></td>
+        <td><div class="unselectable square blanksquare row3 col3 tlbr bltr" id="slot13"></div></td>
+        <td><div class="unselectable square blanksquare row3 col4" id="slot14"></div></td>
+        <td><div class="unselectable square blanksquare row3 col5" id="slot15"></div></td>
     </tr>
     <tr>
         <td class="unselectable popout" id="row4">ROW4</td>
-        <td class="unselectable square blanksquare row4 col1" id="slot16"></td>
-        <td class="unselectable square blanksquare row4 col2 bltr" id="slot17"></td>
-        <td class="unselectable square blanksquare row4 col3" id="slot18"></td>
-        <td class="unselectable square blanksquare row4 col4 tlbr" id="slot19"></td>
-        <td class="unselectable square blanksquare row4 col5" id="slot20"></td>
+        <td><div class="unselectable square blanksquare row4 col1" id="slot16"></div></td>
+        <td><div class="unselectable square blanksquare row4 col2 bltr" id="slot17"></div></td>
+        <td><div class="unselectable square blanksquare row4 col3" id="slot18"></div></td>
+        <td><div class="unselectable square blanksquare row4 col4 tlbr" id="slot19"></div></td>
+        <td><div class="unselectable square blanksquare row4 col5" id="slot20"></div></td>
     </tr>
     <tr>
         <td class="unselectable popout" id="row5">ROW5</td>
-        <td class="unselectable square blanksquare row5 col1 bltr" id="slot21"></td>
-        <td class="unselectable square blanksquare row5 col2" id="slot22"></td>
-        <td class="unselectable square blanksquare row5 col3" id="slot23"></td>
-        <td class="unselectable square blanksquare row5 col4" id="slot24"></td>
-        <td class="unselectable square blanksquare row5 col5 tlbr" id="slot25"></td>
+        <td><div class="unselectable square blanksquare row5 col1 bltr" id="slot21"></div></td>
+        <td><div class="unselectable square blanksquare row5 col2" id="slot22"></div></td>
+        <td><div class="unselectable square blanksquare row5 col3" id="slot23"></div></td>
+        <td><div class="unselectable square blanksquare row5 col4" id="slot24"></div></td>
+        <td><div class="unselectable square blanksquare row5 col5 tlbr" id="slot25"></div></td>
     </tr>
     <tr>
         <td class="unselectable popout" id="bltr">BL-TR</td>

--- a/bingosync-app/templates/bingosync/room_settings_panel.html
+++ b/bingosync-app/templates/bingosync/room_settings_panel.html
@@ -11,8 +11,7 @@
         <table id="settings-table">
             <tr><td><b>Seed:</b></td><td>{{ game.seed }}</td></tr>
             <tr><td><b>Game:</b></td><td>{{ game.game_type }}</td></tr>
-            <tr><td><b>Mode:</b></td><td>Blackout</td></tr>
-            <tr><td>Multi</td><td><input id="allow-multi-color" type="checkbox"></td></tr>
+            <tr><td><b>Mode:</b></td><td>{{ game.lockout_mode }}<div id="is-lockout" class="hidden" value="{% if game.lockout_mode_value == 2 %}lockout{% else %}non_lockout{% endif %}"></td></tr>
         </table>
     </div>
 </div>

--- a/bingosync-app/templates/bingosync/room_settings_panel.html
+++ b/bingosync-app/templates/bingosync/room_settings_panel.html
@@ -12,6 +12,7 @@
             <tr><td><b>Seed:</b></td><td>{{ game.seed }}</td></tr>
             <tr><td><b>Game:</b></td><td>{{ game.game_type }}</td></tr>
             <tr><td><b>Mode:</b></td><td>Blackout</td></tr>
+            <tr><td>Multi</td><td><input id="allow-multi-color" type="checkbox"></td></tr>
         </table>
     </div>
 </div>


### PR DESCRIPTION
Adds a non-lockout mode so multiple colors can be selected for the same square.
![bingo_sync_multiple](https://cloud.githubusercontent.com/assets/6477924/13031975/24c5e02e-d2a7-11e5-99bf-85c9f0c481ac.png)

The old behavior is "Lockout" mode, the lockout mode can be selected when creating a room.
![lockout_mode](https://cloud.githubusercontent.com/assets/6477924/13031980/650ae828-d2a7-11e5-8eff-74506b9cffea.png)

Adds a lockout mode field to the game schema and a removeColor field for the GoalEvent schema (the color portion of a goal event is now the same for removing and adding, removeColor will be true for removing a color)
Changes the values of colors in the square schema to accomodate multiple colors, values are now defined by the CompositeColor class.
The value is made by adding powers of 2 together (basically bitwise operations) e.g. 1 = red, 4 = green, 5 = red and green etc.
