### PR TITLE
Increase contrast between colors

### DIFF
--- a/bingosync-app/static/bingosync/style.css
+++ b/bingosync-app/static/bingosync/style.css
@@ -205,19 +205,19 @@
 
 /* ripped these gradients from the slate theme (Edited by FelixNemis) */
 .greensquare {
-    background-image: linear-gradient(#49ac25, #429412 20%, #337e03);
+    background-image: linear-gradient(#49ac25, #60ad12 20%, #498403);
 }
 
 .redsquare {
-    background-image: linear-gradient(#e1524b, #ee322f 20%, #c22722);
+    background-image: linear-gradient(#e3524a, #eb3633 20%, #be2f27);
 }
 
 .orangesquare {
-    background-image: linear-gradient(#faa143, #f89406 20%, #e48806);
+    background-image: linear-gradient(#faa143, #f87c06 20%, #e48806);
 }
 
 .bluesquare {
-    background-image: linear-gradient(#74aae3, #5b95de 20%, #4a72db);
+    background-image: linear-gradient(#70b7f5, #759cea 20%, #577ce0);
 }
 
 .purplesquare {

--- a/bingosync-app/static/bingosync/style.css
+++ b/bingosync-app/static/bingosync/style.css
@@ -135,7 +135,7 @@
 /* plain old square */
 .square {
     color: #fff;
-    text-shadow: 1px 1px 1px rgba(0,0,0,0.5);
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.7);
     padding: 0 5px;
     cursor: pointer;
     width: 105px;
@@ -203,26 +203,25 @@
     background: #1448b3;
 }
 
-/* ripped these gradients from the slate theme */
+/* ripped these gradients from the slate theme (Edited by FelixNemis) */
 .greensquare {
-    background-image: linear-gradient(#78cc78, #62c462 60%, #53be53);
+    background-image: linear-gradient(#49ac25, #429412 20%, #337e03);
 }
 
 .redsquare {
-    background-image: linear-gradient(#f17a77, #ee5f5b 60%, #ec4d49);
+    background-image: linear-gradient(#e1524b, #ee322f 20%, #c22722);
 }
 
 .orangesquare {
-    background-image: linear-gradient(#faa123, #f89406 60%, #e48806);
+    background-image: linear-gradient(#faa143, #f89406 20%, #e48806);
 }
 
 .bluesquare {
-    background-image: linear-gradient(#74cae3, #5bc0de 60%, #4ab9db);
+    background-image: linear-gradient(#74aae3, #5b95de 20%, #4a72db);
 }
 
-/* had to generate this one using an online tool... */
 .purplesquare {
-    background-image: linear-gradient(#da75ff, #bf0fff);
+    background-image: linear-gradient(#da3fef, #bf0fff 20%, #b70edf);
 }
 
 .goalcounter {

--- a/bingosync-app/static/bingosync/style.css
+++ b/bingosync-app/static/bingosync/style.css
@@ -213,7 +213,7 @@
 }
 
 .orangesquare {
-    background-image: linear-gradient(#faa143, #f87c06 20%, #e48806);
+    background-image: linear-gradient(#faa143, #e28c3a 20%, #d88613);
 }
 
 .bluesquare {


### PR DESCRIPTION
Modified colors to increase contrast between them, this is especially helpful for blue and green.

Old:
![old_contrast](https://cloud.githubusercontent.com/assets/6477924/13198821/e7e6c4ca-d7d8-11e5-8bfe-d23f27604493.png)

New:
![new_contrast](https://cloud.githubusercontent.com/assets/6477924/13198822/e7e753ea-d7d8-11e5-885e-739752177e55.png)