### PR TITLE
Fix text size of goals on card reveal, hide seed while card is hidden

### DIFF
--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -106,7 +106,7 @@ def room_board(request, encoded_room_uuid):
 # AJAX view to render the room settings panel
 def room_settings(request, encoded_room_uuid):
     room = Room.get_for_encoded_uuid(encoded_room_uuid)
-    panel = loader.get_template("bingosync/room_settings_panel.html").render({"game": room.current_game}, request)
+    panel = loader.get_template("bingosync/room_settings_panel.html").render({"game": room.current_game, "room": room}, request)
     return JsonResponse({"panel": panel, "settings": room.settings});
 
 @csrf_exempt

--- a/bingosync-app/static/bingosync/bingosync.js
+++ b/bingosync-app/static/bingosync/bingosync.js
@@ -333,8 +333,11 @@ function initializeChatSocket($chatWindow, $board, $playersPanel, $chatSettings,
             var newCardMessage = playerName + " generated a new card for " + $("<span>", {"class": "game-title", text: json["game"]}).toHtml() + ". ";
             if (json["game"] !== "Custom (Advanced)") {
                 newCardMessage += " seed: ";
-                //newCardMessage += $("<span>", {"class": "seed", text: json["seed"]}).toHtml();
-                newCardMessage += $("<span>", {"class": "seed-wait", text: '...'}).toHtml();
+                if (json["is_current"]) {
+                    newCardMessage += $("<span>", {"class": "seed-wait", text: '...'}).toHtml();
+                } else {
+                    newCardMessage += $("<span>", {"class": "seed", text: json["seed"]}).toHtml();
+                }
             }
             return $("<div>", {"class": "new-card-message", html: timeHtml + " " + newCardMessage}).toHtml();
         }
@@ -380,6 +383,7 @@ function initializeChatSocket($chatWindow, $board, $playersPanel, $chatSettings,
             var entry = $("<div>", {"class": chatJson["type"] + "-entry", html: message});
             $chatHistory.append(entry);
         }
+        $seedInChat = $("#bingo-chat .new-card-message .seed-wait").removeClass('seed-wait').addClass('seed-hidden').text("Hidden");
         if($chatBody[0] !== undefined) {
             $chatBody.scrollTop($chatBody[0].scrollHeight);
         }

--- a/bingosync-app/templates/bingosync/bingosync.html
+++ b/bingosync-app/templates/bingosync/bingosync.html
@@ -63,7 +63,6 @@
             "{{ key }}": {% autoescape off %}{{ value|format_js_val }}{% endautoescape %},
         {% endfor %}
         };
-        console.log(ROOM_SETTINGS);
 
         var boardUrl = "{% url 'room_board' room.encoded_uuid %}";
         var chatHistoryUrl = "{% url 'room_feed' room.encoded_uuid %}";

--- a/bingosync-app/templates/bingosync/bingosync.html
+++ b/bingosync-app/templates/bingosync/bingosync.html
@@ -112,12 +112,13 @@
                 $("#room-settings-container").html(result.panel);
                 roomSettingsCollapserEvent();
                 ROOM_SETTINGS = result.settings;
+                $seedInChat = $("#bingo-chat .new-card-message .seed-wait").removeClass('seed-wait');
                 if (ROOM_SETTINGS.hide_card) {
-                    $('.board-cover').show();
-                    $(".board-container").addClass('hidden-card');
+                    hideBoard();
+                    $seedInChat.text("Hidden").addClass('seed-hidden');
                 } else {
-                    $('.board-cover').hide();
-                    $(".board-container").removeClass('hidden-card');
+                    revealBoard();
+                    $seedInChat.text(ROOM_SETTINGS.seed).addClass('seed');
                 }
                 refreshNewCardDialog();
             },

--- a/bingosync-app/templates/bingosync/history.html
+++ b/bingosync-app/templates/bingosync/history.html
@@ -32,7 +32,11 @@
                                 <td>{{ room.creator.name }}</td>
                                 <td title="{{ room.created_date }}">{{ room.created_date|timesince }} ago</td>
                                 <td>{{ room.current_game.game_type|hovertext_game_type }}</td>
-                                <td>{{ room.current_game.seed }}</td>
+                                {% if room.is_seed_hidden %}
+                                    <td>Hidden</td>
+                                {% else %}
+                                    <td>{{ room.current_game.seed }}</td>
+                                {% endif %}
                                 <td>{{ room.players|length }}</td>
                             </tr>
                         {% endfor %}

--- a/bingosync-app/templates/bingosync/room_settings_panel.html
+++ b/bingosync-app/templates/bingosync/room_settings_panel.html
@@ -11,7 +11,7 @@
     </div>
     <div class="panel-body">
         <table id="settings-table">
-            <tr><td><b>Seed:</b></td><td>{{ game.seed }}</td></tr>
+            <tr><td><b>Seed:</b></td><td><span id="the-seed">{% if room.settings.hide_card %}<strong>Hidden<strong>{% else %}{{ game.seed }}{% endif %}</span></td></tr>
             <tr><td><b>Game:</b></td><td>{{ game.game_type|hovertext_game_type }}</td></tr>
             <tr><td><b>Mode:</b></td><td>{{ game.lockout_mode }}</td></tr>
             <tr><td colspan="2">


### PR DESCRIPTION
When the board is hidden, the seed is still visible and people could use this to peak at the card early.
This hides the seed from the visible and hidden markup and javascript log, it's not impossible to get the seed but at least it's not trivial now :P 
Also fixes the automatic text fitting in goals when the board is revealed.
Also hides console logging of all incoming events.