### PR TITLE
add sockets_url to socket key api

### DIFF
--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -298,6 +298,7 @@ def get_socket_key(request, encoded_room_uuid):
     player = _get_session_player(request.session, room)
     data = {
         "socket_key": _create_temporary_socket_key(player),
+        "sockets_url": SOCKETS_URL,
     }
     return JsonResponse(data)
 


### PR DESCRIPTION
The use case it that I want to support bingosync and also other instances at the same time, so the user just drops in the complete bingosync link with room code so I can make a request to the `join-room` api endpoint to get the socket key.

However, there is currently no way I'm aware of to get the url the sockets server is hosted at.

The only (really hacky) solution would be to mimic the normal user signin process and then grab the sockets url from the html with a regex or something, which is definitely not ideal.

So instead just send the `sockets_url` along with the `socket_key`.