### PR TITLE
Remove profanity from SMM2's Board.

### DIFF
--- a/bingosync-app/generators/mario_maker_2_generator.js
+++ b/bingosync-app/generators/mario_maker_2_generator.js
@@ -45,7 +45,7 @@ var bingoList = [
     "Super Mario 3 level",
     "Super Mario 3d world level",
     "Switch/rhythm blocks",
-    "Too many fucking spikes",
+    "Too many spikes",
     "Twister",
     "Under 60 seconds",
     "Vertical sublevel",


### PR DESCRIPTION
fixes #300, removes 'fucking' from the 'Too many fucking spikes' goal description in Super Mario Maker 2.